### PR TITLE
Delete on termination capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 2.0.1
+
+This release includes:
+- Delete on termination capability for ec2_volume attachments
+
 ## Supported Version 2.0.0
 
 This release includes:

--- a/lib/puppet/provider/ec2_volume/v2.rb
+++ b/lib/puppet/provider/ec2_volume/v2.rb
@@ -77,7 +77,10 @@ Puppet::Type.type(:ec2_volume).provide(:v2, :parent => PuppetX::Puppetlabs::Aws)
     Puppet.info("Attaching Volume #{volume_id} to ec2 instance #{config[:instance_id]}")
     ec2.wait_until(:volume_available, volume_ids: [volume_id])
     ec2.attach_volume(config)
+    Puppet.info("Has key: #{resource[:attach].has_key?("delete_on_termination")}")
+    Puppet.info("dot value: #{resource[:attach]["delete_on_termination"]}")
     if (resource[:attach].has_key?("delete_on_termination") ? resource[:attach]["delete_on_termination"] : false) then
+      Puppet.info("Modifying instance attribute delete_on_termination=#{resource[:attach]["delete_on_termination"]} for resource[:attach]["device"] on ec2 instance #{config[:instance_id]}")
       config = {}
       config[:instance_id] = resource[:attach]["instance_id"]
       config[:block_device_mappings] = [{ :device_name=> resource[:attach]["device"], :ebs=> { :delete_on_termination=> true } }]

--- a/lib/puppet/provider/ec2_volume/v2.rb
+++ b/lib/puppet/provider/ec2_volume/v2.rb
@@ -80,7 +80,7 @@ Puppet::Type.type(:ec2_volume).provide(:v2, :parent => PuppetX::Puppetlabs::Aws)
     if (resource[:attach].has_key?("delete_on_terminate") ? resource[:attach]["delete_on_terminate"] : false) then
       config = {}
       config[:instance_id] = resource[:attach]["instance_id"]
-      config[:block_device_mappings] = [{"DeviceName": resource[:attach]["device"], "Ebs": { "DeleteOnTermination": true } }]
+      config[:block_device_mappings] = [{"DeviceName"=> resource[:attach]["device"], "Ebs"=> { "DeleteOnTermination"=> true } }]
       ec2.modify_instance_attribute(config)
     end
   end

--- a/lib/puppet/provider/ec2_volume/v2.rb
+++ b/lib/puppet/provider/ec2_volume/v2.rb
@@ -77,6 +77,12 @@ Puppet::Type.type(:ec2_volume).provide(:v2, :parent => PuppetX::Puppetlabs::Aws)
     Puppet.info("Attaching Volume #{volume_id} to ec2 instance #{config[:instance_id]}")
     ec2.wait_until(:volume_available, volume_ids: [volume_id])
     ec2.attach_volume(config)
+    if (resource[:attach].has_key?("delete_on_terminate") ? resource[:attach]["delete_on_terminate"] : false) then
+      config = {}
+      config[:instance_id] = resource[:attach]["instance_id"]
+      config[:block_device_mappings] = [{"DeviceName": resource[:attach]["device"], "Ebs": { "DeleteOnTermination": true } }]
+      ec2.modify_instance_attribute(config)
+    end
   end
 
   def create

--- a/lib/puppet/provider/ec2_volume/v2.rb
+++ b/lib/puppet/provider/ec2_volume/v2.rb
@@ -77,8 +77,6 @@ Puppet::Type.type(:ec2_volume).provide(:v2, :parent => PuppetX::Puppetlabs::Aws)
     Puppet.info("Attaching Volume #{volume_id} to ec2 instance #{config[:instance_id]}")
     ec2.wait_until(:volume_available, volume_ids: [volume_id])
     ec2.attach_volume(config)
-    Puppet.info("Has key: #{resource[:attach].has_key?("delete_on_termination")}")
-    Puppet.info("dot value: #{resource[:attach]["delete_on_termination"]}")
     if (resource[:attach].has_key?("delete_on_termination") ? resource[:attach]["delete_on_termination"] : false) then
       Puppet.info("Modifying instance attribute delete_on_termination=#{resource[:attach]["delete_on_termination"]} for #{resource[:attach]["device"]} on ec2 instance #{config[:instance_id]}")
       config = {}

--- a/lib/puppet/provider/ec2_volume/v2.rb
+++ b/lib/puppet/provider/ec2_volume/v2.rb
@@ -80,7 +80,7 @@ Puppet::Type.type(:ec2_volume).provide(:v2, :parent => PuppetX::Puppetlabs::Aws)
     Puppet.info("Has key: #{resource[:attach].has_key?("delete_on_termination")}")
     Puppet.info("dot value: #{resource[:attach]["delete_on_termination"]}")
     if (resource[:attach].has_key?("delete_on_termination") ? resource[:attach]["delete_on_termination"] : false) then
-      Puppet.info("Modifying instance attribute delete_on_termination=#{resource[:attach]["delete_on_termination"]} for resource[:attach]["device"] on ec2 instance #{config[:instance_id]}")
+      Puppet.info("Modifying instance attribute delete_on_termination=#{resource[:attach]["delete_on_termination"]} for #{resource[:attach]["device"]} on ec2 instance #{config[:instance_id]}")
       config = {}
       config[:instance_id] = resource[:attach]["instance_id"]
       config[:block_device_mappings] = [{ :device_name=> resource[:attach]["device"], :ebs=> { :delete_on_termination=> true } }]

--- a/lib/puppet/provider/ec2_volume/v2.rb
+++ b/lib/puppet/provider/ec2_volume/v2.rb
@@ -80,7 +80,7 @@ Puppet::Type.type(:ec2_volume).provide(:v2, :parent => PuppetX::Puppetlabs::Aws)
     if (resource[:attach].has_key?("delete_on_termination") ? resource[:attach]["delete_on_termination"] : false) then
       config = {}
       config[:instance_id] = resource[:attach]["instance_id"]
-      config[:block_device_mappings] = [{ "DeviceName"=> resource[:attach]["device"], "Ebs"=> { "DeleteOnTermination"=> true } }]
+      config[:block_device_mappings] = [{ :device_name=> resource[:attach]["device"], :ebs=> { :delete_on_termination=> true } }]
       ec2.modify_instance_attribute(config)
     end
   end

--- a/lib/puppet/provider/ec2_volume/v2.rb
+++ b/lib/puppet/provider/ec2_volume/v2.rb
@@ -77,10 +77,10 @@ Puppet::Type.type(:ec2_volume).provide(:v2, :parent => PuppetX::Puppetlabs::Aws)
     Puppet.info("Attaching Volume #{volume_id} to ec2 instance #{config[:instance_id]}")
     ec2.wait_until(:volume_available, volume_ids: [volume_id])
     ec2.attach_volume(config)
-    if (resource[:attach].has_key?("delete_on_terminate") ? resource[:attach]["delete_on_terminate"] : false) then
+    if (resource[:attach].has_key?("delete_on_termination") ? resource[:attach]["delete_on_termination"] : false) then
       config = {}
       config[:instance_id] = resource[:attach]["instance_id"]
-      config[:block_device_mappings] = [{"DeviceName"=> resource[:attach]["device"], "Ebs"=> { "DeleteOnTermination"=> true } }]
+      config[:block_device_mappings] = [{ "DeviceName"=> resource[:attach]["device"], "Ebs"=> { "DeleteOnTermination"=> true } }]
       ec2.modify_instance_attribute(config)
     end
   end

--- a/lib/puppet/provider/ec2_volume/v2.rb
+++ b/lib/puppet/provider/ec2_volume/v2.rb
@@ -36,6 +36,7 @@ Puppet::Type.type(:ec2_volume).provide(:v2, :parent => PuppetX::Puppetlabs::Aws)
       {
         instance_id: att.instance_id,
         device: att.device,
+        delete_on_termination: att.delete_on_termination
       }
     end
     config = {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-aws",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "puppetlabs",
   "summary": "This module provides the ability to manage AWS resources",
   "license": "Apache-2.0",


### PR DESCRIPTION
New optional parameter (```attach[:delete_on_termination]```) on ec2_volume resource type.
Defaults to old behaviour (do NOT delete on termination).