### PR TITLE
Mse sc latest snapshot

### DIFF
--- a/lib/puppet/provider/ec2_volume/v2.rb
+++ b/lib/puppet/provider/ec2_volume/v2.rb
@@ -86,6 +86,7 @@ Puppet::Type.type(:ec2_volume).provide(:v2, parent: PuppetX::Puppetlabs::Aws) do
   def latest_snapshot
     return resource[:snapshot_id] if resource[:snapshot_id]
     return false unless resource[:snapshot_label]
+    Puppet.notice("Attempting to fetch snapshot ID")
     latest = find_snapshots.first
     Puppet.notice("Restoring volume from snapshot #{latest.snapshot_id}" \
       "taken #{latest.start_time}")
@@ -95,7 +96,7 @@ Puppet::Type.type(:ec2_volume).provide(:v2, parent: PuppetX::Puppetlabs::Aws) do
   def find_snapshots
     filters = [{
       name: 'description',
-      values: [snapshot_label]
+      values: [resource[:snapshot_label]]
     }, {
       name: 'status',
       values: ['completed']

--- a/lib/puppet/provider/ec2_volume/v2.rb
+++ b/lib/puppet/provider/ec2_volume/v2.rb
@@ -78,13 +78,14 @@ Puppet::Type.type(:ec2_volume).provide(:v2, parent: PuppetX::Puppetlabs::Aws) do
   end
 
   def create_from_snapshot(config)
-    snapshot = resource[:snapshot_id] ? latest_snapshot : false
+    snapshot = latest_snapshot
     config['snapshot_id'] = snapshot if snapshot
     config
   end
 
   def latest_snapshot
-    return resource[:snapshot_id] unless resource[:snapshot_id] == '@latest'
+    return resource[:snapshot_id] if resource[:snapshot_id]
+    return false unless resource[:snapshot_label]
     latest = find_snapshots.first
     Puppet.notice("Restoring volume from snapshot #{latest.snapshot_id}" \
       "taken #{latest.start_time}")

--- a/lib/puppet/provider/ec2_volume/v2.rb
+++ b/lib/puppet/provider/ec2_volume/v2.rb
@@ -89,7 +89,7 @@ Puppet::Type.type(:ec2_volume).provide(:v2, parent: PuppetX::Puppetlabs::Aws) do
     latest = find_snapshots.first
     Puppet.notice("Restoring volume from snapshot #{latest.snapshot_id}" \
       "taken #{latest.start_time}")
-    latest
+    latest.snapshot_id
   end
 
   def find_snapshots

--- a/lib/puppet/type/ec2_volume.rb
+++ b/lib/puppet/type/ec2_volume.rb
@@ -71,6 +71,13 @@ Puppet::Type.newtype(:ec2_volume) do
     end
   end
 
+  newproperty(:snapshot_label) do
+    desc 'Label of the snapshot that this volume should be created from'
+    validate do |value|
+      fail 'snapshot_label should be an string' unless value.is_a?(String)
+    end
+  end
+
   newproperty(:attach) do
     desc 'The ec2 instance that this volume should attach to'
     validate do |value|

--- a/lib/puppet/type/ec2_volume.rb
+++ b/lib/puppet/type/ec2_volume.rb
@@ -67,14 +67,14 @@ Puppet::Type.newtype(:ec2_volume) do
   newproperty(:snapshot_id) do
     desc 'The snapshot that this volume should be created from'
     validate do |value|
-      fail 'snapshot_id should be an string' unless value.is_a?(String)
+      fail 'snapshot_id should be a string' unless value.is_a?(String)
     end
   end
 
   newproperty(:snapshot_label) do
     desc 'Label of the snapshot that this volume should be created from'
     validate do |value|
-      fail 'snapshot_label should be an string' unless value.is_a?(String)
+      fail 'snapshot_label should be a string' unless value.is_a?(String)
     end
   end
 
@@ -99,7 +99,7 @@ Puppet::Type.newtype(:ec2_volume) do
   newproperty(:kms_key_id) do
     desc 'The full ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) to use when creating the encrypted volume.'
     validate do |value|
-      fail 'kms_key_id should be an string' unless value.is_a?(String)
+      fail 'kms_key_id should be a string' unless value.is_a?(String)
     end
   end
 


### PR DESCRIPTION
Adding the ability to specify a snapshot label to restore from the latest snapshot

Use-case:
Mongo restore test nodes need to find and mount the latest snapshot and test the data so cannot use a specific snapshot id easily