### PR TITLE
removing rescue param for retries so it retries on all errors

### DIFF
--- a/lib/puppet/provider/ec2_volume/v2.rb
+++ b/lib/puppet/provider/ec2_volume/v2.rb
@@ -27,7 +27,6 @@ Puppet::Type.type(:ec2_volume).provide(:v2, parent: PuppetX::Puppetlabs::Aws) do
 
   def self.prefetch(resources)
     with_retries(:max_tries => @@RETRIES,
-
                  :base_sleep_seconds => 30,
                  :max_sleep_seconds => 60) do |attempt|
       Puppet.notice("Attempt #{attempt} of prefetch ebs volume")

--- a/lib/puppet/provider/ec2_volume/v2.rb
+++ b/lib/puppet/provider/ec2_volume/v2.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:ec2_volume).provide(:v2, parent: PuppetX::Puppetlabs::Aws) do
 
   def self.prefetch(resources)
     with_retries(:max_tries => @@RETRIES,
-                 :rescue => Aws::EC2::Errors::RequestLimitExceeded,
+
                  :base_sleep_seconds => 30,
                  :max_sleep_seconds => 60) do |attempt|
       Puppet.notice("Attempt #{attempt} of prefetch ebs volume")
@@ -91,7 +91,6 @@ Puppet::Type.type(:ec2_volume).provide(:v2, parent: PuppetX::Puppetlabs::Aws) do
 
   def attach_instance(volume_id)
     with_retries(:max_tries => @@RETRIES,
-                 :rescue => Aws::EC2::Errors::RequestLimitExceeded,
                  :base_sleep_seconds => 30,
                  :max_sleep_seconds => 60) do |attempt|
       Puppet.notice("Attempt #{attempt} of attaching ebs volume")
@@ -114,7 +113,6 @@ Puppet::Type.type(:ec2_volume).provide(:v2, parent: PuppetX::Puppetlabs::Aws) do
 
   def create
     with_retries(:max_tries => @@RETRIES,
-                 :rescue => Aws::EC2::Errors::RequestLimitExceeded,
                  :base_sleep_seconds => 30,
                  :max_sleep_seconds => 60) do |attempt|
       Puppet.notice("Attempt #{attempt} of creating ebs volume")
@@ -149,7 +147,6 @@ Puppet::Type.type(:ec2_volume).provide(:v2, parent: PuppetX::Puppetlabs::Aws) do
 
   def destroy
     with_retries(:max_tries => @@RETRIES,
-                 :rescue => Aws::EC2::Errors::RequestLimitExceeded,
                  :base_sleep_seconds => 30,
                  :max_sleep_seconds => 60) do |attempt|
       Puppet.notice("Attempt #{attempt} of destroying ebs volume")


### PR DESCRIPTION
removing rescue param for retries so it retries on all errors

https://jira1-eu1.moneysupermarketgroup.com/browse/OPCOR-364